### PR TITLE
log -> logrus

### DIFF
--- a/fws/creds.go
+++ b/fws/creds.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"os/user"
 	"path/filepath"

--- a/fws/resource_fws_database.go
+++ b/fws/resource_fws_database.go
@@ -2,7 +2,7 @@ package fws
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-fakewebservices/client"

--- a/fws/resource_fws_load_balancer.go
+++ b/fws/resource_fws_load_balancer.go
@@ -2,7 +2,7 @@ package fws
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-fakewebservices/client"

--- a/fws/resource_fws_server.go
+++ b/fws/resource_fws_server.go
@@ -2,7 +2,7 @@ package fws
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-fakewebservices/client"

--- a/fws/resource_fws_vpc.go
+++ b/fws/resource_fws_vpc.go
@@ -2,7 +2,7 @@ package fws
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-fakewebservices/client"

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-provider-fakewebservices/fws"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)